### PR TITLE
Version 0.4.0: Remove unnecessary install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ osx_image: xcode10.2
 
 jobs:
   include:
-  - script: swift test
-    stage: test
+  - stage: test
   - script: swift run danger-swift ci
     install: npm install -g danger
     stage: danger
@@ -24,12 +23,6 @@ directories:
 # Danger Swift plugins, like Yams
 - .build
 - ~/.danger-swift
-
-#install: #Only install Danger on the danger stage
-## Grab the latest Danger JS from npm
-#- npm install -g danger
-## Compile the Danger runtime
-#- swift build
 
 script:
 - swift test

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming]
 
+Some stuff
+
+## [0.4.0] - 2019-08-03
+
 ## [0.3.0] - 2019-07-29
 
 ## [0.2.0] - 2019-07-26


### PR DESCRIPTION
danger-swift is a dependency of my test target, so I can't test without building it